### PR TITLE
Build the package in parallel

### DIFF
--- a/argos3.rb
+++ b/argos3.rb
@@ -29,8 +29,8 @@ class Argos3 < Formula
     mkdir "build_simulator"
     cd "build_simulator"
     system "cmake", "../src", "-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_INSTALL_PREFIX=#{prefix}", "-DARGOS_BUILD_NATIVE=ON", "-DCPACK_PACKAGE_VERSION_MAJOR=#{VERSION_MAJOR}", "-DCPACK_PACKAGE_VERSION_MINOR=#{VERSION_MINOR}", "-DCPACK_PACKAGE_VERSION_PATCH=#{VERSION_PATCH}", "-DCPACK_PACKAGE_RELEASE=#{VERSION_RELEASE}", "-DARGOS_BREW_QT_CELLAR=#{HOMEBREW_PREFIX}/Cellar/qt"
-    system "make"
-    system "make doc"
+    system "cmake --build . --target all --parallel"
+    system "cmake --build . --target doc --parallel"
     system "make install"
   end
 

--- a/argos3.rb
+++ b/argos3.rb
@@ -29,9 +29,9 @@ class Argos3 < Formula
     mkdir "build_simulator"
     cd "build_simulator"
     system "cmake", "../src", "-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_INSTALL_PREFIX=#{prefix}", "-DARGOS_BUILD_NATIVE=ON", "-DCPACK_PACKAGE_VERSION_MAJOR=#{VERSION_MAJOR}", "-DCPACK_PACKAGE_VERSION_MINOR=#{VERSION_MINOR}", "-DCPACK_PACKAGE_VERSION_PATCH=#{VERSION_PATCH}", "-DCPACK_PACKAGE_RELEASE=#{VERSION_RELEASE}", "-DARGOS_BREW_QT_CELLAR=#{HOMEBREW_PREFIX}/Cellar/qt"
-    system "cmake --build . --target all --parallel"
-    system "cmake --build . --target doc --parallel"
-    system "make install"
+    system "cmake", "--build", ".", "--target", "all", "--parallel"
+    system "cmake", "--build", ".", "--target", "doc", "--parallel"
+    system "make", "install"
   end
 
   test do


### PR DESCRIPTION
This proposed change will decrease install time of the package using `make -j n`

This uses cmake to build with `--parallel` tag, which will internally use -j parameter with appropriate number of threads defined in system.

Tested on Mac OS Catalina, Cmake version: 3.17.0
(not tested through Homebrew, just tested the commands)